### PR TITLE
Support sending raw messages to statsd daemon

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -214,7 +214,16 @@ Client.prototype.send = function (stat, value, type, sampleRate, tags, callback)
   if(merged_tags.length > 0){
     message += '|#' + merged_tags.join(',');
   }
+    
+  this.sendMessage(message, callback);
+};
 
+/**
+ * Sends a raw message across to statsd server
+ * @param message {String} The message to send
+ * @param callback {Function=} Callback when message is done being delivered. Optional.
+ */
+Client.prototype.sendMessage = function (message, callback) {
   // Only send this stat if we're not a mock Client.
   if(!this.mock) {
     buf = new Buffer(message);
@@ -224,7 +233,7 @@ Client.prototype.send = function (stat, value, type, sampleRate, tags, callback)
       callback(null, 0);
     }
   }
-};
+}
 
 /**
  * Close the underlying socket and stop listening for data on it.


### PR DESCRIPTION
Sometimes the API abstraction doesn't help much. With this functionality, the user can directly send a message across the wire. This can be useful when a statsd server supports different metric types (ie. Datadog).